### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 - repo: https://github.com/pycqa/isort
-  rev: 5.8.0
+  rev: 5.10.1
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: 21.5b0
+  rev: 21.10b0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/flake8
-  rev: 3.9.1
+  rev: 4.0.1
   hooks:
   - id: flake8


### PR DESCRIPTION
Ran `pre-commit autoupdate`.

Consider https://pre-commit.ci/ for regular updates (weekly, monthly, or quarterly).