### PR TITLE
Indent CSS functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Use your preferred system for setting up a virtualenv, docker environment,
 or whatever else, then run the following:
 
 ```sh
-python -m pip install -e .[dev]
+python -m pip install -e '.[dev]'
 pre-commit install --install-hooks
 ```
 

--- a/djhtml/modes.py
+++ b/djhtml/modes.py
@@ -292,10 +292,7 @@ class DjCSS(DjTXT):
 
     RAW_TOKENS = DjTXT.RAW_TOKENS + [
         r"</style>",
-        r"{",
-        r"}",
-        r"\(",
-        r"\)",
+        r"[\{\(\)\}]",
         r"/\*",
     ]
 

--- a/djhtml/modes.py
+++ b/djhtml/modes.py
@@ -65,7 +65,10 @@ class DjTXT:
                 # token at the top of the stack.
                 if token.dedents:
                     try:
-                        if stack[-1].kind == token.kind and stack[-1].is_hard == token.is_hard:
+                        if (
+                            stack[-1].kind == token.kind
+                            and stack[-1].is_hard == token.is_hard
+                        ):
                             opening_token = stack.pop()
                         elif token.kind == "django":
                             opening_token = stack.pop()
@@ -79,7 +82,9 @@ class DjTXT:
 
                             # If there is any OpenHard token in the set and current token is CloseHard
                             # then let's move back to OpenHard.
-                            if token.is_hard and any(t.is_hard and t.indents for t in stack):
+                            if token.is_hard and any(
+                                t.is_hard and t.indents for t in stack
+                            ):
                                 s = stack.pop()
                                 while not s.is_hard or not s.indents:
                                     s = stack.pop()
@@ -289,6 +294,8 @@ class DjCSS(DjTXT):
         r"</style>",
         r"{",
         r"}",
+        r"\(",
+        r"\)",
         r"/\*",
     ]
 
@@ -296,9 +303,9 @@ class DjCSS(DjTXT):
         kind = "css"
         self.next_mode = self
 
-        if raw_token == "{":
+        if raw_token in "{(":
             return Token.Open(raw_token, kind)
-        if raw_token == "}":
+        if raw_token in "})":
             return Token.Close(raw_token, kind)
         if raw_token == "/*":
             self.next_mode = Comment(r"\*/", self, kind)

--- a/tests/suite/css.in
+++ b/tests/suite/css.in
@@ -24,3 +24,15 @@ text-decoration: underline;
      *
      */
 </style>
+
+
+<!-- CSS Function -->
+<style>
+#gradient {
+background: linear-gradient(
+to top left,
+rgba(204,0,0,1),
+rgba(204,0,0,0)
+);
+}
+</style>

--- a/tests/suite/css.out
+++ b/tests/suite/css.out
@@ -24,3 +24,15 @@
      *
      */
 </style>
+
+
+<!-- CSS Function -->
+<style>
+    #gradient {
+        background: linear-gradient(
+            to top left,
+            rgba(204,0,0,1),
+            rgba(204,0,0,0)
+        );
+    }
+</style>


### PR DESCRIPTION
I have some code in my template using CSS gradients that looks roughly like this:

```
<style>
    #gradient {
        background: linear-gradient(
            to top left,
            rgba(204,0,0,1),
            rgba(204,0,0,0)
        );
    }
</style>
```

However, djhtml removes the indentation in the function arguments:

```
<style>
    #gradient {
        background: linear-gradient(
        to top left,
        rgba(204,0,0,1),
        rgba(204,0,0,0)
        );
    }
</style>
```

This adds `(` and `)` as tokens in the CSS mode so CSS function arguments are indented one level.

Side note: I skipped creating an issue and went straight to a pull request, but I'm not sure if that's considered impolite. If so, I'm sorry, and I'm happy to go back and create one. Thank you for your hard work on this, I was really excited to discover this project!