### PR TITLE
Further indent HTML attribute values

### DIFF
--- a/tests/suite/html.in
+++ b/tests/suite/html.in
@@ -134,6 +134,38 @@ text
 </div>
 
 
+<!-- Multiline elements -->
+<img src="/some/long/path"
+id="1">
+<blockquote class="dishy"
+id="2" />
+<a href="/some/long/path"
+id="3"></a>
+
+<!-- Multiline attribute values -->
+<svg width="325" height="325" xmlns="http://www.w3.org/2000/svg">
+<path
+d="M 80 80
+A 45 45, 0, 0, 0, 125 125
+L 125 80 Z"
+fill="green"
+/>
+<path
+d="
+M 80 80
+A 45 45, 0, 0, 0, 125 125
+L 125 80 Z
+"
+fill="green"
+/>
+<path d="M 80 80
+A 45 45, 0, 0, 0, 125 125
+L 125 80 Z"
+fill="green"
+/>
+</svg>
+
+
 <!-- Remove trailing spaces -->
 Invisible spaces here:   
 

--- a/tests/suite/html.out
+++ b/tests/suite/html.out
@@ -134,6 +134,38 @@
 </div>
 
 
+<!-- Multiline elements -->
+<img src="/some/long/path"
+    id="1">
+<blockquote class="dishy"
+    id="2" />
+<a href="/some/long/path"
+    id="3"></a>
+
+<!-- Multiline attribute values -->
+<svg width="325" height="325" xmlns="http://www.w3.org/2000/svg">
+    <path
+        d="M 80 80
+            A 45 45, 0, 0, 0, 125 125
+            L 125 80 Z"
+        fill="green"
+    />
+    <path
+        d="
+            M 80 80
+            A 45 45, 0, 0, 0, 125 125
+            L 125 80 Z
+        "
+        fill="green"
+    />
+    <path d="M 80 80
+        A 45 45, 0, 0, 0, 125 125
+        L 125 80 Z"
+        fill="green"
+    />
+</svg>
+
+
 <!-- Remove trailing spaces -->
 Invisible spaces here:
 


### PR DESCRIPTION
This PR implements option 3 from issue #53, because I think that option is the most consistent. There remain a few edge cases that I did not account for, such as:

```html
<path d="
    M 80 80
    A 45 45, 0, 0, 0, 125 125
    L 125 80 Z
"
    fill="green"
/>
```

Closes #53