### PR TITLE
Fix docs for pre-commit hook of DjCSS

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,7 +10,7 @@
 - id: djcss
   name: DjCSS
   entry: djcss -i
-  types: [css]
+  types_or: [css, scss]
   language: python
   language_version: python3
   require_serial: true

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ If you want to limit the files these hooks operate on, you can use the
       files: .*/templates/.*\.html$
     - id: djcss
       # Run this hook on both CSS and SCSS files
-      types: [css, scss]
+      types: []
+      types_or: [css, scss]
     - id: djjs
       # Exclude JavaScript files in vendor directories
       exclude: .*/vendor/.*

--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ repos:
     - id: djjs
 ```
 
-If you want to limit the files these hooks operate on, you can use the
-`files`, `types`, and `exclude` arguments. For example:
+If you want to limit the files these hooks operate on, you can use
+[pre-commit mechanisms for filtering](https://pre-commit.com/#filtering-files-with-types).
+For example:
 
 ```yml
 - repo: https://github.com/rtts/djhtml
@@ -157,9 +158,8 @@ If you want to limit the files these hooks operate on, you can use the
       # Indent only HTML files in template directories
       files: .*/templates/.*\.html$
     - id: djcss
-      # Run this hook on both CSS and SCSS files
-      types: []
-      types_or: [css, scss]
+      # Run this hook only on SCSS files (CSS and SCSS is the default)
+      types: [scss]
     - id: djjs
       # Exclude JavaScript files in vendor directories
       exclude: .*/vendor/.*


### PR DESCRIPTION
Hi there,
I have a project with .css and .scss files. I followed the README.md and found out that it does not work for me.
When I integrated it, It showed me:
> DjCSS................................................(no files to check)Skipped

According to docs,
![Selection_1220](https://user-images.githubusercontent.com/16066485/152811891-2337fcc5-7f20-478c-96db-8028ed9fffea.png)

We see that it should be `types_or` for `OR` filtering. File should be `CSS` **OR** `SCSS`

 