### PR TITLE
Upgrade Black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: 21.10b0
+  rev: 22.3.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
The latest version of click broke old versions of Black, the new Black fixes that. See: https://github.com/psf/black/issues/2976