### PR TITLE
Remove `-i` and `-o` command line options

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,4 +34,4 @@ jobs:
         python -m pip install --upgrade nox
 
     - name: Run tox targets for ${{ matrix.python-version }}
-      run: nox
+      run: nox --session tests-${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
         - 3.8
         - 3.9
         - '3.10'
+        - '3.11'
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 22.12.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/flake8
-  rev: 4.0.1
+  rev: 6.0.0
   hooks:
   - id: flake8

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: djhtml
   name: DjHTML
-  entry: djhtml -i
+  entry: djhtml
   types: [html]
   language: python
   language_version: python3
@@ -9,7 +9,7 @@
 
 - id: djcss
   name: DjCSS
-  entry: djcss -i
+  entry: djcss
   types_or: [css, scss]
   language: python
   language_version: python3
@@ -18,7 +18,7 @@
 
 - id: djjs
   name: DjJS
-  entry: djjs -i
+  entry: djjs
   types: [javascript]
   language: python
   language_version: python3

--- a/README.md
+++ b/README.md
@@ -72,15 +72,8 @@ An exit status of 0 means that everything went well, regardless of
 whether any files were changed. When the option `-c` / `--check` is
 used, the exit status is 1 when one or more files would have changed,
 but no changes are actually made. The exit status of 123 means that
-there was an error while indenting one or more files.
-
-All available options are:
-
-- `-h` / `--help`: show overview of available options
-- `-c` / `--check`: don't modify files; the exit status is the number
-    of files that would have changed
-- `-q` / `--quiet`: don't print any output
-- `-t` / `--tabwidth`: set tabwidth (default is 4)
+there was an error while indenting one or more files. All available
+options are given by `djthml -h` / `djthml --help`.
 
 
 ## `fmt:off` and `fmt:on`

--- a/README.md
+++ b/README.md
@@ -62,29 +62,24 @@ Install DjHTML with the following command:
 ## Usage
 
 After installation you can indent templates using the `djhtml`
-command. The default is to read from standard in and to write the
-indented output to standard out. To modify the source file in-place,
-use the `-i` / `--in-place` option and specify a filename:
+command:
 
-    $ djhtml -i template.html
+    $ djhtml template.html
     reindented template.html
     1 template has been reindented.
 
-Normally, the exit status of 0 means everything went well, regardless
-of whether any files were changed. If any errors were encountered, the
-exit status indicated the number of problematic files. However, when
-the option `-c` / `--check` is used, the exit status is the number of
-files that would have changed, but no changes are actually made.
+An exit status of 0 means that everything went well, regardless of
+whether any files were changed. When the option `-c` / `--check` is
+used, the exit status is 1 when one or more files would have changed,
+but no changes are actually made.
 
 All available options are:
 
 - `-h` / `--help`: show overview of available options
-- `-i` / `--in-place`: modify files in-place
 - `-c` / `--check`: don't modify files; the exit status is the number
     of files that would have changed
 - `-q` / `--quiet`: don't print any output
 - `-t` / `--tabwidth`: set tabwidth (default is 4)
-- `-o` / `--output-file`: write output to specified file
 
 
 ## `fmt:off` and `fmt:on`
@@ -157,7 +152,7 @@ the default tabwidth, you change the `entry` point of these hooks:
     hooks:
       - id: djhtml
         # Use a tabwidth of 2 for HTML files
-        entry: djhtml -i -t 2
+        entry: djhtml --tabwith 2
       - id: djcss
       - id: djjs
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ command:
 An exit status of 0 means that everything went well, regardless of
 whether any files were changed. When the option `-c` / `--check` is
 used, the exit status is 1 when one or more files would have changed,
-but no changes are actually made.
+but no changes are actually made. The exit status of 123 means that
+there was an error while indenting one or more files.
 
 All available options are:
 

--- a/djhtml/__main__.py
+++ b/djhtml/__main__.py
@@ -20,17 +20,20 @@ def main():
     unchanged_files = 0
     problematic_files = 0
 
-    suffixes = [".html"]
-    Mode = modes.DjHTML
-    if sys.argv[0].endswith("djtxt"):
+    # Determine mode based on script name
+    script_name = Path(sys.argv[0])
+    if script_name.stem == "djtxt":
         Mode = modes.DjTXT
         suffixes = [".txt"]
-    if sys.argv[0].endswith("djcss"):
+    elif script_name.stem == "djcss":
         Mode = modes.DjCSS
         suffixes = [".css", ".scss"]
-    if sys.argv[0].endswith("djjs"):
+    elif script_name.stem == "djjs":
         Mode = modes.DjJS
         suffixes = [".js"]
+    else:
+        Mode = modes.DjHTML
+        suffixes = [".html"]
 
     if len(options.input_filenames) > 1 and "-" in options.input_filenames:
         sys.exit("I’m sorry Dave, I’m afraid I can’t do that.")

--- a/djhtml/__main__.py
+++ b/djhtml/__main__.py
@@ -38,9 +38,11 @@ def main():
     for filename in _generate_filenames(options.input_filenames, suffixes):
         # Read input file
         try:
-            input_file = sys.stdin if filename == "-" else open(filename, "r")
-            source = input_file.read()
-            input_file.close()
+            if filename == "-":
+                source = sys.stdin.read()
+            else:
+                with open(filename) as input_file:
+                    source = input_file.read()
         except Exception as e:
             problematic_files += 1
             _error(e)

--- a/djhtml/__main__.py
+++ b/djhtml/__main__.py
@@ -40,11 +40,11 @@ def main():
         try:
             input_file = sys.stdin if filename == "-" else open(filename, "r")
             source = input_file.read()
+            input_file.close()
         except Exception as e:
             problematic_files += 1
-            _error(f"Cannot open {filename}: {e}")
-        finally:
-            input_file.close()
+            _error(e)
+            continue
 
         # Indent input file
         try:
@@ -103,7 +103,7 @@ def main():
 
     # Exit with appropriate exit status
     if problematic_files:
-        sys.exit(1)
+        sys.exit(123)
     if options.check and changed_files:
         sys.exit(1)
     sys.exit(0)
@@ -115,10 +115,10 @@ def _generate_filenames(paths, suffixes):
             yield filename
         else:
             path = Path(filename)
-            if path.is_file():
-                yield path
-            elif path.is_dir():
+            if path.is_dir():
                 yield from _generate_filenames_from_directory(path, suffixes)
+            else:
+                yield path
 
 
 def _generate_filenames_from_directory(directory, suffixes):

--- a/djhtml/__main__.py
+++ b/djhtml/__main__.py
@@ -74,20 +74,20 @@ def main():
             unchanged_files += 1
 
         # Write output file
-        if filename == "-":
-            if not options.check:
-                print(result, end="")
-        elif changed:
-            try:
-                output_file = open(filename, "w")
-                output_file.write(result)
-                output_file.close()
-            except Exception as e:
-                changed_files -= 1
-                problematic_files += 1
-                _error(f"Error writing {filename}: {e}")
-                continue
-            _info(f"reindented {output_file.name}")
+        if not options.check:
+            if filename == "-":
+                if not options.quiet:
+                    print(result, end="")
+            elif changed:
+                try:
+                    with open(filename, "w") as output_file:
+                        output_file.write(result)
+                except Exception as e:
+                    changed_files -= 1
+                    problematic_files += 1
+                    _error(e)
+                    continue
+                _info(f"reindented {output_file.name}")
 
     # Print final summary
     s = "s" if changed_files != 1 else ""

--- a/djhtml/__main__.py
+++ b/djhtml/__main__.py
@@ -1,16 +1,135 @@
-import argparse
+"""
+Entrypoint for all 4 command-line tools. Typical usage:
+
+    $ djhtml file1.html file2.html
+
+Passing "-" as the filename will read from standard input and write to
+standard output. Example usage:
+
+    $ djhtml - < input.html > output.html
+"""
+
 import sys
 from pathlib import Path
 
-from . import modes
+from . import modes, options
 
 
-def verify_changed(source, result):
-    """
-    Verify that the source is either exactly equal to the result or
-    that the result has only changed by added or removed whitespace.
+def main():
+    changed_files = 0
+    unchanged_files = 0
+    problematic_files = 0
 
-    """
+    suffixes = [".html"]
+    Mode = modes.DjHTML
+    if sys.argv[0].endswith("djtxt"):
+        Mode = modes.DjTXT
+        suffixes = [".txt"]
+    if sys.argv[0].endswith("djcss"):
+        Mode = modes.DjCSS
+        suffixes = [".css", ".scss"]
+    if sys.argv[0].endswith("djjs"):
+        Mode = modes.DjJS
+        suffixes = [".js"]
+
+    if len(options.input_filenames) > 1 and "-" in options.input_filenames:
+        sys.exit("I’m sorry Dave, I’m afraid I can’t do that.")
+
+    for filename in _generate_filenames(options.input_filenames, suffixes):
+        # Read input file
+        try:
+            input_file = sys.stdin if filename == "-" else open(filename, "r")
+            source = input_file.read()
+        except Exception as e:
+            problematic_files += 1
+            _error(f"Cannot open {filename}: {e}")
+        finally:
+            input_file.close()
+
+        # Indent input file
+        try:
+            if options.debug:
+                print(Mode(source).debug())
+                sys.exit()
+            result = Mode(source).indent(options.tabwidth)
+        except SyntaxError as e:
+            problematic_files += 1
+            _error(f"Syntax error in {filename}: {str(e) or e.__class__.__name__}")
+            continue
+        except Exception:
+            _error(
+                f"Fatal error while processing {filename}\n\n"
+                "    If you have time and are using the latest version, we\n"
+                "    would very much appreciate if you opened an issue on\n"
+                "    https://github.com/rtts/djhtml/issues\n"
+            )
+            raise
+
+        changed = _verify_changed(source, result)
+        if changed:
+            changed_files += 1
+        else:
+            unchanged_files += 1
+
+        # Write output file
+        if filename == "-":
+            if not options.check:
+                print(result, end="")
+        elif changed:
+            try:
+                output_file = open(filename, "w")
+                output_file.write(result)
+                output_file.close()
+            except Exception as e:
+                changed_files -= 1
+                problematic_files += 1
+                _error(f"Error writing {filename}: {e}")
+                continue
+            _info(f"reindented {output_file.name}")
+
+    # Print final summary
+    s = "s" if changed_files != 1 else ""
+    have = "would have" if options.check else "have" if s else "has"
+    _info(f"{changed_files} template{s} {have} been reindented.")
+    if unchanged_files:
+        s = "s" if unchanged_files != 1 else ""
+        were = "were" if s else "was"
+        _info(f"{unchanged_files} template{s} {were} already perfect!")
+    if problematic_files:
+        s = "s" if problematic_files != 1 else ""
+        _info(
+            f"{problematic_files} template{s} could not be processed due to an error."
+        )
+
+    # Exit with appropriate exit status
+    if problematic_files:
+        sys.exit(1)
+    if options.check and changed_files:
+        sys.exit(1)
+    sys.exit(0)
+
+
+def _generate_filenames(paths, suffixes):
+    for filename in paths:
+        if filename == "-":
+            yield filename
+        else:
+            path = Path(filename)
+            if path.is_file():
+                yield path
+            elif path.is_dir():
+                yield from _generate_filenames_from_directory(path, suffixes)
+
+
+def _generate_filenames_from_directory(directory, suffixes):
+    for path in directory.iterdir():
+        if path.is_file() and path.suffix in suffixes:
+            yield path
+        elif path.is_dir():
+            yield from _generate_filenames_from_directory(path, suffixes)
+
+
+def _verify_changed(source, result):
     output_lines = result.split("\n")
     changed = False
     for line_nr, line in enumerate(source.split("\n")):
@@ -18,193 +137,16 @@ def verify_changed(source, result):
             changed = True
         if line.strip() != output_lines[line_nr].strip():
             raise IndentationError("Non-whitespace changes detected. Core dumped.")
-
     return changed
 
 
-def main():
-    """
-    Entrypoint for all 4 command-line tools. Typical usage:
-
-        $ djhtml -i file1.html file2.html
-
-    """
-    target_extension = ".html"
-    Mode = modes.DjHTML
-    if sys.argv[0].endswith("djtxt"):
-        Mode = modes.DjTXT
-        target_extension = ".txt"
-    if sys.argv[0].endswith("djcss"):
-        Mode = modes.DjCSS
-        target_extension = ".css"
-    if sys.argv[0].endswith("djjs"):
-        Mode = modes.DjJS
-        target_extension = ".js"
-
-    changed_files = 0
-    unchanged_files = 0
-    problematic_files = 0
-
-    parser = argparse.ArgumentParser(
-        description=(
-            "DjHTML is a fully automatic template indenter that works with mixed"
-            " HTML/CSS/Javascript templates that contain Django or Jinja template"
-            " tags. It works similar to other code-formatting tools such as Black and"
-            " interoperates nicely with pre-commit. Full documentation can be found at"
-            " https://github.com/rtts/djhtml"
-        ),
-    )
-    parser.add_argument(
-        "-i", "--in-place", action="store_true", help="modify files in-place"
-    )
-    parser.add_argument("-c", "--check", action="store_true", help="don't modify files")
-    parser.add_argument("-q", "--quiet", action="store_true", help="be quiet")
-    parser.add_argument(
-        "-t",
-        "--tabwidth",
-        metavar="N",
-        type=int,
-        default=4,
-        help="tabwidth (default is 4)",
-    )
-    parser.add_argument(
-        "-o",
-        "--output-file",
-        metavar="filename",
-        default="-",
-        help="output filename",
-    )
-    parser.add_argument(
-        "input_filenames",
-        metavar="filenames",
-        nargs="*",
-        default=["-"],
-        help="input filenames (either paths or directories)",
-    )
-    parser.add_argument("-d", "--debug", action="store_true", help=argparse.SUPPRESS)
-    args = parser.parse_args()
-
-    if args.in_place and "-" in args.input_filenames:
-        sys.exit("I’m sorry Dave, I’m afraid I can’t do that")
-
-    if len(args.input_filenames) > 1 and not args.in_place and not args.check:
-        sys.exit("Will not modify files in-place without -i option")
-
-    for input_filename in _generate_files(args.input_filenames, target_extension):
-        # Read input file
-        try:
-            input_file = (
-                sys.stdin if input_filename == "-" else open(input_filename, "r")
-            )
-            source = input_file.read()
-        except Exception as e:
-            problematic_files += 1
-            if not args.quiet:
-                print(f"Error opening {input_filename}: {e}", file=sys.stderr)
-            continue
-
-        # Indent input file
-        try:
-            if args.debug:
-                print(Mode(source).debug())
-                sys.exit()
-            result = Mode(source).indent(args.tabwidth)
-        except SyntaxError as e:
-            problematic_files += 1
-            if not args.quiet:
-                print(
-                    f"Syntax error in {input_file.name}:"
-                    f" {str(e) or e.__class__.__name__}",
-                    file=sys.stderr,
-                )
-            continue
-        except Exception:
-            print(
-                f"\nFatal error while processing {input_file.name}\n\n"
-                "    If you have time and are using the latest version, we\n"
-                "    would very much appreciate if you opened an issue on\n"
-                "    https://github.com/rtts/djhtml/issues\n",
-                file=sys.stderr,
-            )
-            raise
-        finally:
-            input_file.close()
-
-        changed = verify_changed(source, result)
-
-        # Print to stdout and exit
-        if not args.in_place and not args.check and args.output_file == "-":
-            if not args.quiet:
-                print(result, end="")
-            sys.exit(1 if args.check and changed else 0)
-
-        # Write output file
-        if changed and args.check:
-            changed_files += 1
-        elif changed:
-            output_filename = input_file.name if args.in_place else args.output_file
-            try:
-                output_file = open(output_filename, "w")
-                output_file.write(result)
-                output_file.close()
-                changed_files += 1
-            except Exception as e:
-                problematic_files += 1
-                if not args.quiet:
-                    print(f"Error writing {output_filename}: {e}", file=sys.stderr)
-                continue
-            if not args.quiet:
-                print(
-                    f"reindented {output_file.name}",
-                    file=sys.stderr,
-                )
-        else:
-            unchanged_files += 1
-
-    # Print final summary
-    if not args.quiet:
-        s = "s" if changed_files != 1 else ""
-        have = "would have" if args.check else "have" if s else "has"
-        print(
-            f"{changed_files} template{s} {have} been reindented.",
-            file=sys.stderr,
-        )
-        if unchanged_files:
-            s = "s" if unchanged_files != 1 else ""
-            were = "were" if s else "was"
-            print(
-                f"{unchanged_files} template{s} {were} already perfect!",
-                file=sys.stderr,
-            )
-        if problematic_files:
-            s = "s" if problematic_files != 1 else ""
-            print(
-                f"{problematic_files} template{s} could not be processed due to an"
-                " error.",
-                file=sys.stderr,
-            )
-
-    sys.exit(changed_files if args.check else problematic_files)
+def _info(msg):
+    if not options.quiet:
+        print(msg, file=sys.stderr)
 
 
-def _generate_files(input_filenames, suffix):
-    for file_name in input_filenames:
-        if file_name == "-":
-            yield file_name
-        else:
-            file_path = Path(file_name)
-            if file_path.is_file():
-                yield file_path
-            elif file_path.is_dir():
-                yield from _generate_files_from_folder(file_path, suffix)
-
-
-def _generate_files_from_folder(folder, suffix):
-    for file_path in folder.iterdir():
-        if file_path.is_file() and file_path.suffix == suffix:
-            yield file_path
-        elif file_path.is_dir():
-            yield from _generate_files_from_folder(file_path, suffix)
+def _error(msg):
+    _info(f"Error: {msg}")
 
 
 if __name__ == "__main__":

--- a/djhtml/__main__.py
+++ b/djhtml/__main__.py
@@ -57,10 +57,6 @@ def main():
                 print(Mode(source).debug())
                 sys.exit()
             result = Mode(source).indent(options.tabwidth)
-        except SyntaxError as e:
-            problematic_files += 1
-            _error(f"Syntax error in {filename}: {str(e) or e.__class__.__name__}")
-            continue
         except Exception:
             _error(
                 f"Fatal error while processing {filename}\n\n"

--- a/djhtml/modes.py
+++ b/djhtml/modes.py
@@ -80,8 +80,9 @@ class DjTXT:
                             # to what it would have been with a
                             # regular text token.
 
-                            # If there is any OpenHard token in the set and current token is CloseHard
-                            # then let's move back to OpenHard.
+                            # If there is any OpenHard token in the
+                            # set and current token is CloseHard then
+                            # let's move back to OpenHard.
                             if token.is_hard and any(
                                 t.is_hard and t.indents for t in stack
                             ):

--- a/djhtml/options.py
+++ b/djhtml/options.py
@@ -47,7 +47,10 @@ args = parser.parse_args(namespace=self)
 
 if self.in_place:
     sys.exit(
-        "The -i (--in-place) argument has been deprecated as it's now the default. If"
-        " you have a custom pre-commit entry for DjHTML, remove the -i argument from it"
-        " and everything will continue to work as before."
+        """
+You have called DjHTML with the -i or --in-place argument which
+has been deprecated as it's now the default. If you have a custom
+pre-commit entry for DjHTML, remove the -i argument from it and
+everything will continue to work as before.
+"""
     )

--- a/djhtml/options.py
+++ b/djhtml/options.py
@@ -1,0 +1,53 @@
+"""
+Options set by command-line arguments. Usage:
+
+    import options
+    print(f"Tabwidth is {options.tabwidth}")
+"""
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(
+    description=(
+        "DjHTML is a fully automatic template indenter that works with mixed"
+        " HTML/CSS/Javascript templates that contain Django or Jinja template"
+        " tags. It works similar to other code-formatting tools such as Black and"
+        " interoperates nicely with pre-commit. Full documentation can be found at"
+        " https://github.com/rtts/djhtml"
+    ),
+)
+parser.add_argument(
+    "-c",
+    "--check",
+    action="store_true",
+    help="check indentation without modifying files",
+)
+parser.add_argument("-q", "--quiet", action="store_true", help="be quiet")
+parser.add_argument(
+    "-t",
+    "--tabwidth",
+    metavar="N",
+    type=int,
+    default=4,
+    help="tabwidth (default is 4)",
+)
+parser.add_argument(
+    "input_filenames",
+    metavar="filename",
+    nargs="+",
+    help="input filenames (either paths or directories)",
+)
+parser.add_argument("-d", "--debug", action="store_true", help=argparse.SUPPRESS)
+parser.add_argument("-i", "--in-place", action="store_true", help=argparse.SUPPRESS)
+
+# Parse arguments and assign attributes to self
+self = sys.modules[__name__]
+args = parser.parse_args(namespace=self)
+
+if self.in_place:
+    sys.exit(
+        "The -i (--in-place) argument has been deprecated as it's now the default. If"
+        " you have a custom pre-commit entry for DjHTML, remove the -i argument from it"
+        " and everything will continue to work as before."
+    )

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"])
 def tests(session):
     session.run("python", "-m", "unittest", "discover", "-v")

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ console_scripts =
 
 [flake8]
 max-line-length = 88
-select = C,E,F,W,B,B950
-extend-ignore = E203, E501
-extend-exclude = .nox
+extend-ignore = E203
+
+[isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: OS Independent
 python_requires = '>=3.6'


### PR DESCRIPTION
The `-i` and `-o` command line options have been removed, and the argument parsing has been moved to a separate `options` module. Finally, a small bug (#70) has been fixed as well.