### PR TITLE
Add per-file output to --check and add -q flag

### DIFF
--- a/djhtml/__main__.py
+++ b/djhtml/__main__.py
@@ -103,10 +103,9 @@ def main():
                     problematic_files += 1
                     _error(e)
                     continue
-                if not options.quiet:
-                    _info(f"reindented {output_file.name}")
-        elif not options.quiet and filename != "-":
-            _info(f"{filename} would be reindented.")
+                _info(f"reindented {output_file.name}")
+        elif changed and filename != "-":
+            _info(f"would have reindented {filename}")
 
     # Print final summary
     s = "s" if changed_files != 1 else ""

--- a/djhtml/__main__.py
+++ b/djhtml/__main__.py
@@ -103,7 +103,10 @@ def main():
                     problematic_files += 1
                     _error(e)
                     continue
-                _info(f"reindented {output_file.name}")
+                if not options.quiet:
+                    _info(f"reindented {output_file.name}")
+        elif not options.quiet and filename != "-":
+            _info(f"{filename} would be reindented.")
 
     # Print final summary
     s = "s" if changed_files != 1 else ""

--- a/djhtml/options.py
+++ b/djhtml/options.py
@@ -43,12 +43,6 @@ parser.add_argument(
     help="check indentation without modifying files",
 )
 parser.add_argument(
-    "-q",
-    "--quiet",
-    action="store_true",
-    help="don't print informational messages per file",
-)
-parser.add_argument(
     "-t",
     "--tabwidth",
     metavar="N",

--- a/djhtml/options.py
+++ b/djhtml/options.py
@@ -43,6 +43,12 @@ parser.add_argument(
     help="check indentation without modifying files",
 )
 parser.add_argument(
+    "-q",
+    "--quiet",
+    action="store_true",
+    help="don't print informational messages per file",
+)
+parser.add_argument(
     "-t",
     "--tabwidth",
     metavar="N",


### PR DESCRIPTION
This will show _which_ files would have been formatted when running with --check. The old behaviour can be restored by using --check --quiet.

I need this for CI, where it's usually desirable to have both the non-zero exit code and actionable and informative feedback.

The `--quiet` flag makes it possible to restore the original quiet behaviour with `--check --quiet`, and may also be nice for people who want a quiet option without `--check`.